### PR TITLE
Ensure Unique OrderId in get_shipments response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/spree/endpoint_base.git
-  revision: 5a819541b20ade1b7ec6eb19f38fbab7eaf3e14e
+  revision: 40db9bb54c764540f69dd7bdeddf9ff023b05ad5
   specs:
     endpoint_base (0.3)
       activesupport

--- a/lib/mds/responses/shipping_sku_ack.rb
+++ b/lib/mds/responses/shipping_sku_ack.rb
@@ -18,14 +18,16 @@ module MDS
       def objects
         orders = body['Order'].is_a?(Hash) ? [body['Order']] : body['Order']
 
-        orders.to_a.sort_by { |o| o["TrackingNumber"] }.map do |order|
-          {
+        orders.to_a.sort_by { |o| o["TrackingNumber"] }.inject({}) do |h, order|
+          h[order["OrderID"]] = {
             id: order["OrderID"],
             status: "shipped",
             tracking: order["TrackingNumber"],
             shipped_at: parse_date(order["OrderShipDate"])
           }
-        end
+
+          h
+        end.values
       end
 
       def parse_date(date)

--- a/lib/mds/responses/shipping_sku_ack.rb
+++ b/lib/mds/responses/shipping_sku_ack.rb
@@ -18,7 +18,7 @@ module MDS
       def objects
         orders = body['Order'].is_a?(Hash) ? [body['Order']] : body['Order']
 
-        orders.to_a.map do |order|
+        orders.to_a.sort_by { |o| o["TrackingNumber"] }.map do |order|
           {
             id: order["OrderID"],
             status: "shipped",


### PR DESCRIPTION
If an order has two tracking numbers then this API call will
return two xml elements with the same order ID. The sort order
that these are returned is not guaranteed.

Sorting by the tracking number will ensure a consistent ordering
for orders with multiple tracking numbers. Only returning one tracking number per order
will ensure that a shipment update event is not triggered each time this flow is run.