### PR TITLE
Push company field to ShipCompany field in order XML

### DIFF
--- a/lib/mds/services/base.rb
+++ b/lib/mds/services/base.rb
@@ -23,17 +23,19 @@ module MDS
         credentials[:client_code] ||= ENV['MDS_CLIENT_CODE'] if ENV['MDS_CLIENT_CODE'].present?
         credentials[:client_signature] ||= ENV['MDS_CLIENT_SIGNATURE'] if ENV['MDS_CLIENT_SIGNATURE'].present?
         credentials[:test_mode] ||= ENV['MDS_TEST_MODE'] if ENV['MDS_TEST_MODE'].present?
+        credentials[:debug_mode] ||= ENV['MDS_DEBUG_MODE'] if ENV['MDS_DEBUG_MODE'].present?
 
         @client_code = credentials.fetch(:client_code)
         @client_signature = credentials.fetch(:client_signature)
         @test_mode = credentials.fetch(:test_mode, "1")
+        @debug_mode = credentials.fetch(:debug_mode, nil) || @test_mode
       end
 
       def query(object = {})
         payload = builder(object).to_xml
         xml_response = HTTParty.get(
           "#{mds_url}/#{self.class.url_package}/ReceiveXML.aspx?xml=" + URI.encode(payload),
-          debug_output: @test_mode == '1' ? $stdout : nil
+          debug_output: @debug_mode == '1' ? $stdout : nil
         )
         build_response_instance(xml_response)
       end

--- a/lib/mds/services/submit_order.rb
+++ b/lib/mds/services/submit_order.rb
@@ -14,6 +14,7 @@ module MDS
             xml.OrderDate       DateTime.parse(shipment[:placed_on]).strftime('%F %R')
             xml.ShippingMethod  shipment[:shipping_method]
             xml.Shipname        "#{shipment[:shipping_address][:firstname]} #{shipment[:shipping_address][:lastname]}"
+            xml.ShipCompany     shipment[:shipping_address][:company]
             xml.ShipAddress1    shipment[:shipping_address][:address1]
             xml.ShipAddress2    shipment[:shipping_address][:address2]
             xml.ShipCity        shipment[:shipping_address][:city]

--- a/lib/mds/services/submit_order.rb
+++ b/lib/mds/services/submit_order.rb
@@ -8,12 +8,10 @@ module MDS
       
       def builder(shipment)
         xml_builder do |xml|
-          if shipment[:shipping_address][:company]
-            shipment[:shipping_address][:company].gsub!('&', '%26amp;')
-          end
+          fix_encoding(shipment[:shipping_address][:company])
 
           ship_name = "#{shipment[:shipping_address][:firstname]} #{shipment[:shipping_address][:lastname]}"
-          ship_name.gsub!('&', '%26amp;')
+          fix_encoding(ship_name)
 
           xml.Order do
             xml.OrderID         shipment[:id]
@@ -68,7 +66,10 @@ module MDS
       def setup_billing_information(xml, shipment)
         billing_address = shipment[:billing_address] || shipment[:shipping_address]
 
-        xml.Billname        "#{billing_address[:firstname]} #{billing_address[:lastname]}"
+        bill_name = "#{billing_address[:firstname]} #{billing_address[:lastname]}"
+        fix_encoding(bill_name)
+
+        xml.Billname        bill_name
         xml.BillAddress1    billing_address[:address1]
         xml.BillAddress2    billing_address[:address2]
         xml.BillCity        billing_address[:city]
@@ -76,6 +77,15 @@ module MDS
         xml.BillCountry     billing_address[:country]
         xml.BillZip         billing_address[:zipcode]
       end
+
+      protected
+
+        # MDS has some strange encoding requirements because of the frameworks they are using
+        def fix_encoding(string)
+          return if string.blank?
+
+          string.gsub!('&', '%26amp;')
+        end
     end
   end
 end

--- a/lib/mds/services/submit_order.rb
+++ b/lib/mds/services/submit_order.rb
@@ -8,6 +8,10 @@ module MDS
       
       def builder(shipment)
         xml_builder do |xml|
+          if shipment[:shipping_address][:company]
+            shipment[:shipping_address][:company].gsub!('&', '%26amp;')
+          end
+          
           xml.Order do
             xml.OrderID         shipment[:id]
             xml.ConsumerPONum   shipment[:id]

--- a/lib/mds/services/submit_order.rb
+++ b/lib/mds/services/submit_order.rb
@@ -11,13 +11,16 @@ module MDS
           if shipment[:shipping_address][:company]
             shipment[:shipping_address][:company].gsub!('&', '%26amp;')
           end
-          
+
+          ship_name = "#{shipment[:shipping_address][:firstname]} #{shipment[:shipping_address][:lastname]}"
+          ship_name.gsub!('&', '%26amp;')
+
           xml.Order do
             xml.OrderID         shipment[:id]
             xml.ConsumerPONum   shipment[:id]
             xml.OrderDate       DateTime.parse(shipment[:placed_on]).strftime('%F %R')
             xml.ShippingMethod  shipment[:shipping_method]
-            xml.Shipname        "#{shipment[:shipping_address][:firstname]} #{shipment[:shipping_address][:lastname]}"
+            xml.Shipname        ship_name
             xml.ShipCompany     shipment[:shipping_address][:company]
             xml.ShipAddress1    shipment[:shipping_address][:address1]
             xml.ShipAddress2    shipment[:shipping_address][:address2]


### PR DESCRIPTION
`:company` is not a standard shipment JSON field. However, it is an optional field in the spree store and most systems support a first name + last name + organization field when supplying shipping information.

Any thoughts on adding `company` to the standard shipping JSON schema?