### PR TITLE
Generate XML without carriage returns to reduce payload size

### DIFF
--- a/lib/mds/services/base.rb
+++ b/lib/mds/services/base.rb
@@ -30,7 +30,7 @@ module MDS
       end
 
       def query(object = {})
-        payload = builder(object).to_xml
+        payload = builder(object).to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
         xml_response = HTTParty.get(
           "#{mds_url}/#{self.class.url_package}/ReceiveXML.aspx?xml=" + URI.encode(payload),
           debug_output: @test_mode == '1' ? $stdout : nil


### PR DESCRIPTION
Large XML payloads will trigger an error on MDS's end. Eliminating carriage returns reduces the chance of hitting their internal payload limit.