### PR TITLE
Default to 2 instead of 3 days of shipping data

### DIFF
--- a/lib/mds/services/shipping_status/tracking.rb
+++ b/lib/mds/services/shipping_status/tracking.rb
@@ -10,7 +10,7 @@ module MDS
         def initialize(config)
           super
 
-          @number_of_days = config[:number_of_days] || 3
+          @number_of_days = config[:number_of_days] || 2
         end
 
         def builder(_)


### PR DESCRIPTION
2 days leave enough room for downtime error. If MDS returns > 1000 items
wombat errors out. This leaves the ability to ship 500 items a day and not bring down wombat